### PR TITLE
feat(parser): add \mathord, \mathrel, \mathbin, \mathop, \mathopen, \mathclose, \mathpunct, \mathinner

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A pull parser for $\LaTeX$ parsing and `mathml` rendering.
 
-[__Try it out!__](https://carloskiki.github.io/pulldown-latex/)
+[**Try it out!**](https://carloskiki.github.io/pulldown-latex/)
 
 This project is inspired `KaTeX`, `Temml`, `MathJax`, etc. It is actively maintained, and is in a stage of development where
 95% of what `KaTeX` and the likes support is properly working and minimally tested. This software
@@ -15,19 +15,20 @@ This crate requires `Rust` version `1.74.1` or higher.
 
 ## Goals
 
-__Follow modern LaTeX principles:__
+**Follow modern LaTeX principles:**
 Ideally, this library should be mostly compatible with `latex2e` and `amsmath`. The term
 _mostly_ is used here to refer to the mathematical commands exposed by these packages; typesetting prose
 is out of scope for this crate. Another consequence of this goal is that some plain-TeX commands that
 are deprecated (e.g., `\atop`, `\over`, etc.) are not supported by this crate.
 
-__Closely resemble conventional LaTeX:__
+**Closely resemble conventional LaTeX:**
 It is a goal for this crate to make efforts in generating aesthetic equations. This means that
 the `mathml` output may be tweaked to make it resemble what `pdflatex`, `KaTeX` or `MathJax` outputs.
 
 ## Development Notes
 
 ### To Test
+
 - [x] All the things `temml` and `katex` test
 - [ ] Errors
 - [ ] Comments parsing
@@ -35,9 +36,9 @@ the `mathml` output may be tweaked to make it resemble what `pdflatex`, `KaTeX` 
 - [ ] Cargo Mutants
 
 ### TODO's/Known Bugs
+
 - [ ] raise and lower boxes.
 - [ ] `\sideset`
-- [ ] `\mathop`, `\mathbin`, etc.
 - [ ] Correctly use the `accent` attribute: https://w3c.github.io/mathml-core/#dfn-accent
 - [ ] Match the `mathml` API to `pulldown-cmark`s API.
 - [ ] Square bracket matrices do not have equal spacing on the left and the right in Chromium.
@@ -46,31 +47,31 @@ the `mathml` output may be tweaked to make it resemble what `pdflatex`, `KaTeX` 
 ## Unsupported Plain-TeX & LaTeX behavior
 
 - Changing `catcode`s of characters
-- `\if`* macros
+- `\if`\* macros
 - `^^_` & `^^[0-9a-f][0-9a-f]` as a way of specifying characters
-- __Redefining active characters__
-    This library currently only supports default active characters, and hence does not allow for the 
-    definition of active characters.
+- **Redefining active characters**
+  This library currently only supports default active characters, and hence does not allow for the
+  definition of active characters.
 - Implicit characters as whitespace tokens
-    As in the TeXbook p. 265, Knuth specifies that a `space token` stands for an _explicit_ or _implicit_
-    space. This library does not currently support _implicit_ space tokens when a `space token` is required.
+  As in the TeXbook p. 265, Knuth specifies that a `space token` stands for an _explicit_ or _implicit_
+  space. This library does not currently support _implicit_ space tokens when a `space token` is required.
 - Use of internal values and parameters, such as registers, and things like `\tolerance`
-    (See TeXbook p. 267 for a complete definition)
+  (See TeXbook p. 267 for a complete definition)
 - `\magnification` parameter & `true` sizes
-- Case insensitive keywords matching. 
-    According to TeXbook p. 265, keywords such as `pt`, `em`, `mm`, etc. are matched case insensitively (e.g.,
-    `pT` would match `pt`). This library does not support this behavior, as keywords must match exactly (i.e., 
-    `em`, `mm`, `pt`, etc.).
+- Case insensitive keywords matching.
+  According to TeXbook p. 265, keywords such as `pt`, `em`, `mm`, etc. are matched case insensitively (e.g.,
+  `pT` would match `pt`). This library does not support this behavior, as keywords must match exactly (i.e.,
+  `em`, `mm`, `pt`, etc.).
 - `fil` units
-    TeX allows the use of `fil`(ll...) units, this library does not.
+  TeX allows the use of `fil`(ll...) units, this library does not.
 - `\outer` specifier on definitions
 - `\edef`, we do not support pre-expansion of macros.
 - `\csname` & `\endcsname`
-- `\begingroup` and `{`, and `\endgroup` and `}` behave the same way; that is to say, 
-    `\begingroup` and `\endgroup` do not have the property of "keeping the same mode" (TeXbook p. 275),
-    which only makes sense in text mode.
+- `\begingroup` and `{`, and `\endgroup` and `}` behave the same way; that is to say,
+  `\begingroup` and `\endgroup` do not have the property of "keeping the same mode" (TeXbook p. 275),
+  which only makes sense in text mode.
 - All vertical list manipulation commands.
-    Things like `\vskip`, `\vfil`, `\moveleft` etc.
+  Things like `\vskip`, `\vfil`, `\moveleft` etc.
 - `\hfil`, `\hfill`
 - `\over`, `\atop`, and all deprecated "fraction like" control sequences.
 
@@ -86,6 +87,7 @@ the `mathml` output may be tweaked to make it resemble what `pdflatex`, `KaTeX` 
 - `\toggle` groups
 
 ## Miscellaneous References & Tools
+
 Sources used during the development of this crate. Any reference in code comments refer to
 these links specifically.
 
@@ -98,4 +100,3 @@ these links specifically.
 - [Font tester](https://fred-wang.github.io/MathFonts/)
 - [Math Variant Selection](https://milde.users.sourceforge.net/LUCR/Math/math-font-selection.xhtml#math-styles)
 - [Official Latex Unicode Data](https://github.com/latex3/unicode-data)
-

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A pull parser for $\LaTeX$ parsing and `mathml` rendering.
 
-[**Try it out!**](https://carloskiki.github.io/pulldown-latex/)
+[__Try it out!__](https://carloskiki.github.io/pulldown-latex/)
 
 This project is inspired `KaTeX`, `Temml`, `MathJax`, etc. It is actively maintained, and is in a stage of development where
 95% of what `KaTeX` and the likes support is properly working and minimally tested. This software
@@ -15,20 +15,19 @@ This crate requires `Rust` version `1.74.1` or higher.
 
 ## Goals
 
-**Follow modern LaTeX principles:**
+__Follow modern LaTeX principles:__
 Ideally, this library should be mostly compatible with `latex2e` and `amsmath`. The term
 _mostly_ is used here to refer to the mathematical commands exposed by these packages; typesetting prose
 is out of scope for this crate. Another consequence of this goal is that some plain-TeX commands that
 are deprecated (e.g., `\atop`, `\over`, etc.) are not supported by this crate.
 
-**Closely resemble conventional LaTeX:**
+__Closely resemble conventional LaTeX:__
 It is a goal for this crate to make efforts in generating aesthetic equations. This means that
 the `mathml` output may be tweaked to make it resemble what `pdflatex`, `KaTeX` or `MathJax` outputs.
 
 ## Development Notes
 
 ### To Test
-
 - [x] All the things `temml` and `katex` test
 - [ ] Errors
 - [ ] Comments parsing
@@ -36,7 +35,6 @@ the `mathml` output may be tweaked to make it resemble what `pdflatex`, `KaTeX` 
 - [ ] Cargo Mutants
 
 ### TODO's/Known Bugs
-
 - [ ] raise and lower boxes.
 - [ ] `\sideset`
 - [ ] Correctly use the `accent` attribute: https://w3c.github.io/mathml-core/#dfn-accent
@@ -47,31 +45,31 @@ the `mathml` output may be tweaked to make it resemble what `pdflatex`, `KaTeX` 
 ## Unsupported Plain-TeX & LaTeX behavior
 
 - Changing `catcode`s of characters
-- `\if`\* macros
+- `\if`* macros
 - `^^_` & `^^[0-9a-f][0-9a-f]` as a way of specifying characters
-- **Redefining active characters**
-  This library currently only supports default active characters, and hence does not allow for the
-  definition of active characters.
+- __Redefining active characters__
+    This library currently only supports default active characters, and hence does not allow for the 
+    definition of active characters.
 - Implicit characters as whitespace tokens
-  As in the TeXbook p. 265, Knuth specifies that a `space token` stands for an _explicit_ or _implicit_
-  space. This library does not currently support _implicit_ space tokens when a `space token` is required.
+    As in the TeXbook p. 265, Knuth specifies that a `space token` stands for an _explicit_ or _implicit_
+    space. This library does not currently support _implicit_ space tokens when a `space token` is required.
 - Use of internal values and parameters, such as registers, and things like `\tolerance`
-  (See TeXbook p. 267 for a complete definition)
+    (See TeXbook p. 267 for a complete definition)
 - `\magnification` parameter & `true` sizes
-- Case insensitive keywords matching.
-  According to TeXbook p. 265, keywords such as `pt`, `em`, `mm`, etc. are matched case insensitively (e.g.,
-  `pT` would match `pt`). This library does not support this behavior, as keywords must match exactly (i.e.,
-  `em`, `mm`, `pt`, etc.).
+- Case insensitive keywords matching. 
+    According to TeXbook p. 265, keywords such as `pt`, `em`, `mm`, etc. are matched case insensitively (e.g.,
+    `pT` would match `pt`). This library does not support this behavior, as keywords must match exactly (i.e., 
+    `em`, `mm`, `pt`, etc.).
 - `fil` units
-  TeX allows the use of `fil`(ll...) units, this library does not.
+    TeX allows the use of `fil`(ll...) units, this library does not.
 - `\outer` specifier on definitions
 - `\edef`, we do not support pre-expansion of macros.
 - `\csname` & `\endcsname`
-- `\begingroup` and `{`, and `\endgroup` and `}` behave the same way; that is to say,
-  `\begingroup` and `\endgroup` do not have the property of "keeping the same mode" (TeXbook p. 275),
-  which only makes sense in text mode.
+- `\begingroup` and `{`, and `\endgroup` and `}` behave the same way; that is to say, 
+    `\begingroup` and `\endgroup` do not have the property of "keeping the same mode" (TeXbook p. 275),
+    which only makes sense in text mode.
 - All vertical list manipulation commands.
-  Things like `\vskip`, `\vfil`, `\moveleft` etc.
+    Things like `\vskip`, `\vfil`, `\moveleft` etc.
 - `\hfil`, `\hfill`
 - `\over`, `\atop`, and all deprecated "fraction like" control sequences.
 
@@ -87,7 +85,6 @@ the `mathml` output may be tweaked to make it resemble what `pdflatex`, `KaTeX` 
 - `\toggle` groups
 
 ## Miscellaneous References & Tools
-
 Sources used during the development of this crate. Any reference in code comments refer to
 these links specifically.
 
@@ -100,3 +97,4 @@ these links specifically.
 - [Font tester](https://fred-wang.github.io/MathFonts/)
 - [Math Variant Selection](https://milde.users.sourceforge.net/LUCR/Math/math-font-selection.xhtml#math-styles)
 - [Official Latex Unicode Data](https://github.com/latex3/unicode-data)
+

--- a/src/parser/primitives.rs
+++ b/src/parser/primitives.rs
@@ -191,6 +191,24 @@ impl<'b, 'store> InnerParser<'b, 'store> {
 
             // TODO: Operators with '*', for operatorname* and friends
 
+            ////////////////////////////////
+            // Atom-type (\math*) commands //
+            ////////////////////////////////
+            // These commands set the math class of their argument, which
+            // influences spacing in MathML output.
+            "mathord" => return self.atom_group(AtomClass::Ord),
+            "mathop" => {
+                self.state.allow_script_modifiers = true;
+                self.state.script_position = SP::Movable;
+                return self.atom_group(AtomClass::Op);
+            }
+            "mathbin" => return self.atom_group(AtomClass::Bin),
+            "mathrel" => return self.atom_group(AtomClass::Rel),
+            "mathopen" => return self.atom_group(AtomClass::Open),
+            "mathclose" => return self.atom_group(AtomClass::Close),
+            "mathpunct" => return self.atom_group(AtomClass::Punct),
+            "mathinner" => return self.atom_group(AtomClass::Inner),
+
             /////////////////////////
             // Non-Latin Alphabets //
             /////////////////////////
@@ -1861,6 +1879,87 @@ impl<'b, 'store> InnerParser<'b, 'store> {
         Ok(())
     }
 
+    /// Implementation of the `\math<class>` atom-type commands (e.g. `\mathord`,
+    /// `\mathrel`, `\mathbin`, `\mathop`, `\mathopen`, `\mathclose`, `\mathpunct`,
+    /// `\mathinner`).
+    ///
+    /// These commands set the math class of their argument, which determines
+    /// spacing in the rendered MathML output. When the argument is a single
+    /// character, it is emitted as the matching [`Content`] variant. When the
+    /// argument is a group, its contents are parsed normally and wrapped in
+    /// an [`Event::Begin`]/[`Event::End`] pair so that the surrounding
+    /// spacing is governed by the requested atom class.
+    ///
+    /// [`Content`]: crate::event::Content
+    /// [`Event::Begin`]: crate::event::Event::Begin
+    /// [`Event::End`]: crate::event::Event::End
+    fn atom_group(&mut self, class: AtomClass) -> InnerResult<()> {
+        let argument = lex::argument(&mut self.content)?;
+
+        // Try to extract a single ASCII/Unicode character so we can emit a
+        // directly-classified Content variant. This gives the most faithful
+        // spacing for the common case (e.g. `\mathbin{+}`).
+        let single_char: Option<char> = match argument {
+            Argument::Token(Token::Character(char_)) => Some(char_.into()),
+            Argument::Group(s) => {
+                let s = s.trim();
+                let mut chars = s.chars();
+                let first = chars.next();
+                match (first, chars.next()) {
+                    (Some(c), None) => Some(c),
+                    _ => None,
+                }
+            }
+            Argument::Token(Token::ControlSequence(_)) => None,
+        };
+
+        if let Some(c) = single_char {
+            let event = match class {
+                AtomClass::Ord => ordinary(c),
+                AtomClass::Op => E::Content(C::LargeOp {
+                    content: c,
+                    small: false,
+                }),
+                AtomClass::Bin => binary(c),
+                AtomClass::Rel => relation(c),
+                AtomClass::Open => E::Content(C::Delimiter {
+                    content: c,
+                    size: None,
+                    ty: DelimiterType::Open,
+                }),
+                AtomClass::Close => E::Content(C::Delimiter {
+                    content: c,
+                    size: None,
+                    ty: DelimiterType::Close,
+                }),
+                AtomClass::Punct => E::Content(C::Punctuation(c)),
+                AtomClass::Inner => ordinary(c),
+            };
+            self.buffer.push(I::Event(event));
+            return Ok(());
+        }
+
+        // Multi-character group (or a control sequence). For \mathop with a
+        // textual group, emit it as a `Function` so it renders as a
+        // multi-letter operator (mirroring `\operatorname`). Otherwise wrap
+        // the parsed argument in a normal group; the inner content keeps its
+        // own atom classes, but the whole construct presents as an
+        // `Atom::Inner` for spacing purposes — which is what TeX does for
+        // `\mathinner`, and is a reasonable approximation for the other
+        // classes when given multi-token arguments.
+        if matches!(class, AtomClass::Op) {
+            if let Argument::Group(content) = argument {
+                self.buffer.push(I::Event(E::Content(C::Function(content))));
+                return Ok(());
+            }
+        }
+
+        self.buffer.push(I::Event(E::Begin(G::Normal)));
+        self.handle_argument(argument)?;
+        self.buffer.push(I::Event(E::End));
+        Ok(())
+    }
+
     /// Override the `font_state` for the argument to the command.
     fn font_group(&mut self, font: Option<Font>) -> InnerResult<()> {
         let argument = lex::argument(&mut self.content)?;
@@ -2095,12 +2194,30 @@ fn binary(op: char) -> E<'static> {
     })
 }
 
+/// Math atom classes used by the `\math<class>` family of commands.
+///
+/// These mirror the TeXbook's eight atom classes and are used by
+/// [`InnerParser::atom_group`] to pick an appropriate [`Content`] variant
+/// for the argument.
+///
+/// [`Content`]: crate::event::Content
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AtomClass {
+    Ord,
+    Op,
+    Bin,
+    Rel,
+    Open,
+    Close,
+    Punct,
+    Inner,
+}
+
 // TODO implementations:
 // - `raise`, `lower`
 // - `hbox`, `mbox`?
 // - `vcenter`
 // - `rule`
-// - `math_` atoms
 // - `mathchoice` (TeXbook p. 151)
 
 // Unimplemented primitives:

--- a/tests/atom_types.rs
+++ b/tests/atom_types.rs
@@ -1,0 +1,104 @@
+//! Tests for amsmath atom-type commands: `\mathord`, `\mathrel`, `\mathbin`,
+//! `\mathop`, `\mathopen`, `\mathclose`, `\mathpunct`, `\mathinner`.
+
+use pulldown_latex::{push_mathml, Parser, Storage};
+
+/// Parse the input and render to MathML, asserting both succeed.
+fn render(input: &str) -> String {
+    let storage = Storage::new();
+    let parser = Parser::new(input, &storage);
+    // First, ensure the parser produces no errors.
+    let errors: Vec<_> = Parser::new(input, &storage)
+        .filter_map(|e| e.err())
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "expected no parse errors for {:?}, got {:?}",
+        input,
+        errors
+    );
+
+    let mut out = String::new();
+    push_mathml(&mut out, parser, Default::default())
+        .unwrap_or_else(|e| panic!("rendering failed for {:?}: {}", input, e));
+    out
+}
+
+#[test]
+fn mathord_single_char() {
+    let out = render(r"\mathord{+}");
+    // A single `+` wrapped in \mathord should render as <mi>+</mi>
+    // (Ordinary class), not as a <mo> (BinaryOp class).
+    assert!(
+        out.contains("<mi>+</mi>") || out.contains("<mi mathvariant=\"normal\">+</mi>"),
+        "expected <mi>+</mi> in {out}"
+    );
+}
+
+#[test]
+fn mathrel_single_char() {
+    let out = render(r"a \mathrel{R} b");
+    // The `R` should be wrapped in <mo> with relation-style spacing.
+    assert!(out.contains("<mo>R</mo>"), "expected <mo>R</mo> in {out}");
+}
+
+#[test]
+fn mathbin_single_char() {
+    let out = render(r"a \mathbin{*} b");
+    // `*` is a binary operator by default; wrapping in \mathbin should still
+    // give us a binary-class atom.
+    assert!(
+        out.contains("<mo>*</mo>") || out.contains("<mo>*</mo>"),
+        "expected <mo>*</mo> in {out}"
+    );
+}
+
+#[test]
+fn mathop_single_char() {
+    let out = render(r"\mathop{X}_{i=1}");
+    // \mathop on a single char should produce an operator with movable scripts.
+    assert!(out.contains("X"), "expected operator X in {out}");
+    // The script should be a subscript via munder/munderover when used in
+    // display mode, but at least the structure should render without error.
+}
+
+#[test]
+fn mathop_multi_char_renders_as_function() {
+    let out = render(r"\mathop{foo}(x)");
+    // Multi-letter \mathop should render like \operatorname{foo} → <mi>foo</mi>.
+    assert!(out.contains("foo"), "expected 'foo' in {out}");
+}
+
+#[test]
+fn mathopen_mathclose() {
+    let out = render(r"\mathopen{[}x\mathclose{]}");
+    // Both delimiters should appear as <mo> with open/close semantics.
+    assert!(out.contains("["), "expected '[' in {out}");
+    assert!(out.contains("]"), "expected ']' in {out}");
+}
+
+#[test]
+fn mathpunct_single_char() {
+    let out = render(r"a\mathpunct{;}b");
+    assert!(out.contains("<mo>;</mo>"), "expected <mo>;</mo> in {out}");
+}
+
+#[test]
+fn mathinner_renders_without_error() {
+    // \mathinner with a group should wrap the contents in an mrow-equivalent
+    // and not error.
+    let out = render(r"\mathinner{abc}");
+    assert!(out.contains("a"), "expected 'a' in {out}");
+    assert!(out.contains("b"), "expected 'b' in {out}");
+    assert!(out.contains("c"), "expected 'c' in {out}");
+}
+
+#[test]
+fn all_atom_commands_parse_in_one_expression() {
+    // Exercise every command in a single string to make sure dispatch and
+    // surrounding-spacing logic don't choke on combinations.
+    let out = render(
+        r"\mathord{a} \mathop{f} \mathbin{+} \mathrel{=} \mathopen{(} x \mathclose{)} \mathpunct{,} \mathinner{y}",
+    );
+    assert!(!out.is_empty());
+}


### PR DESCRIPTION
This PR implements the `amsmath` atom-type commands which set the math class of their argument. 

For single-character arguments, it emits the corresponding `Content` variant (`Ordinary`, `BinaryOp`, `Relation`, `Delimiter`, `Open`/`Close`, `Punctuation`, or `LargeOp` for `\mathop`), so spacing in the generated MathML matches the TeXbook (p. 153 & p. 170).

For multi-character `\mathop` arguments, it emits a `Function` event so they render like `\operatorname{foo}`. For other classes with multi-token arguments, the parsed content is wrapped in a normal group; the surrounding spacing then follows the `Inner` atom class, which matches `\mathinner` and is a reasonable fallback elsewhere.