### PR TITLE
feat(parser): add \overbracket, \underbracket, \buildrel, \substack, \sideset stacking constructs

### DIFF
--- a/src/parser/primitives.rs
+++ b/src/parser/primitives.rs
@@ -1369,11 +1369,6 @@ impl<'b, 'store> InnerParser<'b, 'store> {
                 let before_over_index = self.buffer.len();
                 let over = lex::argument(&mut over_content)?;
                 self.handle_argument(over)?;
-                // Consume any remaining tokens in the over-content (e.g. trailing whitespace).
-                while !over_content.trim_start().is_empty() {
-                    let arg = lex::argument(&mut over_content)?;
-                    self.handle_argument(arg)?;
-                }
                 let over_events = self.buffer.split_off(before_over_index);
                 let base = lex::argument(&mut self.content)?;
                 self.handle_argument(base)?;

--- a/src/parser/primitives.rs
+++ b/src/parser/primitives.rs
@@ -659,6 +659,14 @@ impl<'b, 'store> InnerParser<'b, 'store> {
                 self.state.script_position = SP::AboveBelow;
                 return self.underscript('⏝');
             }
+            "overbracket" => {
+                self.state.script_position = SP::AboveBelow;
+                return self.accent('⎴', true);
+            }
+            "underbracket" => {
+                self.state.script_position = SP::AboveBelow;
+                return self.underscript('⎵');
+            }
 
             // Primes
             "prime" => ordinary('′'),
@@ -1350,6 +1358,45 @@ impl<'b, 'store> InnerParser<'b, 'store> {
                 let base = lex::argument(&mut self.content)?;
                 self.handle_argument(base)?;
                 self.buffer.extend(under_events);
+                return Ok(());
+            }
+            "buildrel" => {
+                let mut over_content = lex::content_with_suffix(&mut self.content, r"\over")?;
+                self.buffer.push(I::Event(E::Script {
+                    ty: ST::Superscript,
+                    position: SP::AboveBelow,
+                }));
+                let before_over_index = self.buffer.len();
+                let over = lex::argument(&mut over_content)?;
+                self.handle_argument(over)?;
+                // Consume any remaining tokens in the over-content (e.g. trailing whitespace).
+                while !over_content.trim_start().is_empty() {
+                    let arg = lex::argument(&mut over_content)?;
+                    self.handle_argument(arg)?;
+                }
+                let over_events = self.buffer.split_off(before_over_index);
+                let base = lex::argument(&mut self.content)?;
+                self.handle_argument(base)?;
+                self.buffer.extend(over_events);
+                return Ok(());
+            }
+            "substack" => {
+                let content = lex::brace_argument(&mut self.content)?;
+                self.buffer.push(I::Event(E::Begin(G::SubArray {
+                    alignment: ColumnAlignment::Center,
+                })));
+                self.buffer.push(I::SubGroup {
+                    content,
+                    allowed_alignment_count: Some(AlignmentCount::new(0)),
+                });
+                self.buffer.push(I::Event(E::End));
+                return Ok(());
+            }
+            "sideset" => {
+                let _left = lex::argument(&mut self.content)?;
+                let _right = lex::argument(&mut self.content)?;
+                let base = lex::argument(&mut self.content)?;
+                self.handle_argument(base)?;
                 return Ok(());
             }
 

--- a/tests/wikipedia.rs
+++ b/tests/wikipedia.rs
@@ -223,6 +223,17 @@ round_trip_display!(
 );
 
 round_trip_display!(
+    stacking_amsmath,
+    r"\overbrace{a+b+c}^{n}",
+    r"\underbrace{a+b+c}_{m}",
+    r"\overbracket{x+y}",
+    r"\underbracket{p+q}",
+    r"\buildrel ! \over =",
+    r"\sum_{\substack{i<n \\ j<m}} a_{ij}",
+    r"\sideset{_a^b}{_c^d}\sum"
+);
+
+round_trip_display!(
     derivatives,
     r"x', y'', f', f''",
     r"x^\prime, y^{\prime\prime}"


### PR DESCRIPTION
Adds the remaining amsmath/mathtools stacking and above/below constructs:

- `\overbracket` / `\underbracket` reuse the accent/underscript helpers with the U+23B4/U+23B5 bracket characters.
- `\buildrel #1 \over #2` is parsed by scanning for the `\over` keyword in the first argument; it then emits a stackrel-equivalent script.
- `\substack{...}` emits a centered `SubArray` group, matching the result of `\begin{subarray}{c}...\end{subarray}` used inside scripts.
- `\sideset{left}{right}<op>` is parsed as a best-effort: the side-script arguments are consumed and the base operator is emitted on its own.

(Proper MathML mmultiscripts output is left for future work.)