### PR TITLE
fix(parser): apply \limits/\nolimits to all big operators (not just \sum)

### DIFF
--- a/src/mathml.rs
+++ b/src/mathml.rs
@@ -475,7 +475,7 @@ where
                     self.env_stack.last()
                 {
                     array_close_line(&mut self.writer, &cols[*cols_index..])?;
-                } else if let Some(Environment::Group(EnvGrouping::Equation { .. })) =
+                } else if let Some(Environment::Group(EnvGrouping::Equation)) =
                     self.env_stack.last()
                 {
                     // LaTeX does _nothing_ when a newline is encountered in an eqution, we do the

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -899,6 +899,59 @@ mod tests {
     }
 
     #[test]
+    fn limits_after_both_scripts_on_int() {
+        // Trailing modifier after both scripts: `\int_a^b\limits` is a real
+        // LaTeX form. The modifier applies to the operator as a whole.
+        let store = Storage::new();
+        let parser = Parser::new(r"\int_a^b\limits", &store);
+        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
+        assert_eq!(events[0], Event::Script {
+            ty: ScriptType::SubSuperscript,
+            position: ScriptPosition::AboveBelow,
+        });
+    }
+
+    #[test]
+    fn nolimits_after_both_scripts_on_sum() {
+        // `\sum` defaults to `Movable`; a trailing `\nolimits` after both
+        // scripts must downgrade it to `Right`.
+        let store = Storage::new();
+        let parser = Parser::new(r"\sum_a^b\nolimits", &store);
+        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
+        assert_eq!(events[0], Event::Script {
+            ty: ScriptType::SubSuperscript,
+            position: ScriptPosition::Right,
+        });
+    }
+
+    #[test]
+    fn nolimits_on_over_under_groups_and_brace() {
+        // `\overgroup`/`\undergroup`/`\underparen`/`\overbrace` all default to
+        // `AboveBelow`; a trailing `\nolimits` downgrades them to `Right`.
+        let store = Storage::new();
+        for src in &[
+            r"\overgroup{ab}\nolimits_x",
+            r"\undergroup{ab}\nolimits_x",
+            r"\underparen{ab}\nolimits_x",
+            r"\overbrace{ab}\nolimits_x",
+        ] {
+            let parser = Parser::new(src, &store);
+            let events = parser
+                .collect::<Result<Vec<_>, ParserError>>()
+                .unwrap_or_else(|e| panic!("`{}` should parse, but got: {}", src, e));
+            assert_eq!(
+                events[0],
+                Event::Script {
+                    ty: ScriptType::Subscript,
+                    position: ScriptPosition::Right,
+                },
+                "wrong script position for `{}`",
+                src,
+            );
+        }
+    }
+
+    #[test]
     fn injlim_and_friends_parse() {
         let store = Storage::new();
         for src in &[

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -808,191 +808,119 @@ mod tests {
         );
     }
 
+    fn render(input: &str) -> String {
+        let storage = Storage::new();
+        let parser = Parser::new(input, &storage);
+        let mut out = String::new();
+        crate::push_mathml(&mut out, parser, crate::RenderConfig::default()).unwrap();
+        out
+    }
+
+    fn assert_contains_tag(input: &str, tag: &str) {
+        let out = render(input);
+        assert!(
+            out.contains(tag),
+            "expected `{tag}` in rendered output for `{input}`, got: {out}"
+        );
+    }
+
     #[test]
     fn limits_on_int() {
-        // `\int` defaults to `Right`-positioned scripts; `\limits` should force
-        // them above/below.
-        let store = Storage::new();
-        let parser = Parser::new(r"\int\limits_a^b", &store);
-        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(
-            events[0],
-            Event::Script {
-                ty: ScriptType::SubSuperscript,
-                position: ScriptPosition::AboveBelow,
-            }
-        );
+        // `\int` defaults to right-positioned scripts; `\limits` should force
+        // them above/below, which renders as `<munderover>`.
+        assert_contains_tag(r"\int\limits_a^b", "<munderover");
     }
 
     #[test]
     fn nolimits_on_int() {
-        let store = Storage::new();
-        let parser = Parser::new(r"\int\nolimits_a^b", &store);
-        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(
-            events[0],
-            Event::Script {
-                ty: ScriptType::SubSuperscript,
-                position: ScriptPosition::Right,
-            }
-        );
+        // `\int\nolimits_a^b` keeps scripts right-positioned: `<msubsup>`.
+        assert_contains_tag(r"\int\nolimits_a^b", "<msubsup");
     }
 
     #[test]
     fn limits_between_scripts() {
-        // `\sum^x\limits_y`: limit modifier appears after the first script. Per
-        // amsmath, it applies to the operator as a whole.
-        let store = Storage::new();
-        let parser = Parser::new(r"\sum^x\limits_y", &store);
-        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(
-            events[0],
-            Event::Script {
-                ty: ScriptType::SubSuperscript,
-                position: ScriptPosition::AboveBelow,
-            }
-        );
+        // `\sum^x\limits_y`: limit modifier appears between the two scripts.
+        // Per amsmath, it applies to the operator as a whole, so the rendered
+        // MathML wraps in `<munderover>`.
+        assert_contains_tag(r"\sum^x\limits_y", "<munderover");
     }
 
     #[test]
     fn nolimits_between_scripts_on_sum() {
-        // `\sum` defaults to `Movable`; `\nolimits` between the scripts must
-        // force `Right`.
-        let store = Storage::new();
-        let parser = Parser::new(r"\sum^x\nolimits_y", &store);
-        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(
-            events[0],
-            Event::Script {
-                ty: ScriptType::SubSuperscript,
-                position: ScriptPosition::Right,
-            }
-        );
+        // `\sum` defaults to movable; `\nolimits` between the scripts must
+        // force right-positioned `<msubsup>`.
+        assert_contains_tag(r"\sum^x\nolimits_y", "<msubsup");
     }
 
     #[test]
     fn limits_repeated_last_wins() {
         // Multiple modifiers — the last one wins (amsmath §7.3).
-        let store = Storage::new();
-        let parser = Parser::new(r"\sum\nolimits\limits\nolimits_a^b", &store);
-        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(
-            events[0],
-            Event::Script {
-                ty: ScriptType::SubSuperscript,
-                position: ScriptPosition::Right,
-            }
-        );
+        assert_contains_tag(r"\sum\nolimits\limits\nolimits_a^b", "<msubsup");
     }
 
     #[test]
     fn limits_on_oint() {
-        // `\oint` is a non-`\sum` big operator that defaults to `Right`.
-        let store = Storage::new();
-        let parser = Parser::new(r"\oint\limits_C f", &store);
-        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(
-            events[0],
-            Event::Script {
-                ty: ScriptType::Subscript,
-                position: ScriptPosition::AboveBelow,
-            }
-        );
+        // `\oint` is a non-`\sum` big operator that defaults to right. With
+        // only a subscript and `\limits`, it renders as `<munder>`.
+        assert_contains_tag(r"\oint\limits_C f", "<munder");
     }
 
     #[test]
     fn nolimits_on_underbrace() {
         // KaTeX/MathJax tolerate `\nolimits` after `\underbrace`, downgrading
-        // its default `AboveBelow` position to `Right`. Without this fix the
-        // parser errored with `unknown primitive command found`.
-        let store = Storage::new();
-        let parser = Parser::new(r"\underbrace{ab}\nolimits_x", &store);
-        let events = parser
-            .collect::<Result<Vec<_>, ParserError>>()
-            .expect("should parse cleanly");
-        assert_eq!(
-            events[0],
-            Event::Script {
-                ty: ScriptType::Subscript,
-                position: ScriptPosition::Right,
-            }
-        );
+        // its default above/below placement to a right-positioned `<msub>`.
+        // Without this fix the parser errored with `unknown primitive command
+        // found`.
+        assert_contains_tag(r"\underbrace{ab}\nolimits_x", "<msub");
     }
 
     #[test]
     fn limits_after_both_scripts_on_int() {
         // Trailing modifier after both scripts: `\int_a^b\limits` is a real
-        // LaTeX form. The modifier applies to the operator as a whole.
-        let store = Storage::new();
-        let parser = Parser::new(r"\int_a^b\limits", &store);
-        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(
-            events[0],
-            Event::Script {
-                ty: ScriptType::SubSuperscript,
-                position: ScriptPosition::AboveBelow,
-            }
-        );
+        // LaTeX form. The modifier applies to the operator as a whole, so the
+        // rendered MathML uses `<munderover>`.
+        assert_contains_tag(r"\int_a^b\limits", "<munderover");
     }
 
     #[test]
     fn nolimits_after_both_scripts_on_sum() {
-        // `\sum` defaults to `Movable`; a trailing `\nolimits` after both
-        // scripts must downgrade it to `Right`.
-        let store = Storage::new();
-        let parser = Parser::new(r"\sum_a^b\nolimits", &store);
-        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(
-            events[0],
-            Event::Script {
-                ty: ScriptType::SubSuperscript,
-                position: ScriptPosition::Right,
-            }
-        );
+        // `\sum` defaults to movable; a trailing `\nolimits` after both scripts
+        // must downgrade it to right-positioned `<msubsup>`.
+        assert_contains_tag(r"\sum_a^b\nolimits", "<msubsup");
     }
 
     #[test]
     fn nolimits_on_over_under_groups_and_brace() {
         // `\overgroup`/`\undergroup`/`\underparen`/`\overbrace` all default to
-        // `AboveBelow`; a trailing `\nolimits` downgrades them to `Right`.
-        let store = Storage::new();
+        // above/below; a trailing `\nolimits` downgrades them to a right-
+        // positioned `<msub>`.
         for src in &[
             r"\overgroup{ab}\nolimits_x",
             r"\undergroup{ab}\nolimits_x",
             r"\underparen{ab}\nolimits_x",
             r"\overbrace{ab}\nolimits_x",
         ] {
-            let parser = Parser::new(src, &store);
-            let events = parser
-                .collect::<Result<Vec<_>, ParserError>>()
-                .unwrap_or_else(|e| panic!("`{}` should parse, but got: {}", src, e));
-            assert_eq!(
-                events[0],
-                Event::Script {
-                    ty: ScriptType::Subscript,
-                    position: ScriptPosition::Right,
-                },
-                "wrong script position for `{}`",
-                src,
-            );
+            assert_contains_tag(src, "<msub");
         }
     }
 
     #[test]
-    fn injlim_and_friends_parse() {
-        let store = Storage::new();
-        for src in &[
-            r"\injlim",
-            r"\projlim",
-            r"\varinjlim",
-            r"\varliminf",
-            r"\varlimsup",
-            r"\varprojlim",
+    fn injlim_and_friends_render() {
+        // Each operator must reach the renderer and emit its function name.
+        // The `var*` forms collapse to plain `lim` per amsmath.
+        for (src, expected) in &[
+            (r"\injlim", "inj lim"),
+            (r"\projlim", "proj lim"),
+            (r"\varinjlim", "lim"),
+            (r"\varliminf", "lim"),
+            (r"\varlimsup", "lim"),
+            (r"\varprojlim", "lim"),
         ] {
-            let parser = Parser::new(src, &store);
-            parser
-                .collect::<Result<Vec<_>, ParserError>>()
-                .unwrap_or_else(|e| panic!("`{}` should parse, but got: {}", src, e));
+            let out = render(src);
+            assert!(
+                out.contains(expected),
+                "`{src}` should render with `{expected}`, got: {out}"
+            );
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -289,6 +289,21 @@ impl<'b, 'store> InnerParser<'b, 'store> {
         let first_script_start = self.buffer.len();
         let arg = lex::argument(&mut self.content)?;
         self.handle_argument(arg)?;
+
+        // `\limits` / `\nolimits` may also appear between two scripts, e.g.
+        // `\sum^x\limits_y`. Per amsmath, repeated limit modifiers are allowed and
+        // the last one wins; the modifier applies to the operator as a whole,
+        // regardless of its position relative to the scripts.
+        if self.state.allow_script_modifiers {
+            if let Some(limits) = lex::limit_modifiers(&mut self.content) {
+                if limits {
+                    self.state.script_position = ScriptPosition::AboveBelow;
+                } else {
+                    self.state.script_position = ScriptPosition::Right;
+                }
+            }
+        }
+
         let second_script_start = self.buffer.len();
         let next_char = self.content.chars().next();
         if (next_char == Some('_') && !subscript_first)
@@ -297,6 +312,18 @@ impl<'b, 'store> InnerParser<'b, 'store> {
             self.content = &self.content[1..];
             let arg = lex::argument(&mut self.content)?;
             self.handle_argument(arg)?;
+
+            // A trailing `\limits` / `\nolimits` after the second script is also
+            // tolerated and applies to the operator as a whole.
+            if self.state.allow_script_modifiers {
+                if let Some(limits) = lex::limit_modifiers(&mut self.content) {
+                    if limits {
+                        self.state.script_position = ScriptPosition::AboveBelow;
+                    } else {
+                        self.state.script_position = ScriptPosition::Right;
+                    }
+                }
+            }
 
             match self.content.chars().next() {
                 Some('_') => return Err(ErrorKind::DoubleSubscript),
@@ -779,6 +806,110 @@ mod tests {
                 }),
             ]
         );
+    }
+
+    #[test]
+    fn limits_on_int() {
+        // `\int` defaults to `Right`-positioned scripts; `\limits` should force
+        // them above/below.
+        let store = Storage::new();
+        let parser = Parser::new(r"\int\limits_a^b", &store);
+        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
+        assert_eq!(events[0], Event::Script {
+            ty: ScriptType::SubSuperscript,
+            position: ScriptPosition::AboveBelow,
+        });
+    }
+
+    #[test]
+    fn nolimits_on_int() {
+        let store = Storage::new();
+        let parser = Parser::new(r"\int\nolimits_a^b", &store);
+        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
+        assert_eq!(events[0], Event::Script {
+            ty: ScriptType::SubSuperscript,
+            position: ScriptPosition::Right,
+        });
+    }
+
+    #[test]
+    fn limits_between_scripts() {
+        // `\sum^x\limits_y`: limit modifier appears after the first script. Per
+        // amsmath, it applies to the operator as a whole.
+        let store = Storage::new();
+        let parser = Parser::new(r"\sum^x\limits_y", &store);
+        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
+        assert_eq!(events[0], Event::Script {
+            ty: ScriptType::SubSuperscript,
+            position: ScriptPosition::AboveBelow,
+        });
+    }
+
+    #[test]
+    fn nolimits_between_scripts_on_sum() {
+        // `\sum` defaults to `Movable`; `\nolimits` between the scripts must
+        // force `Right`.
+        let store = Storage::new();
+        let parser = Parser::new(r"\sum^x\nolimits_y", &store);
+        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
+        assert_eq!(events[0], Event::Script {
+            ty: ScriptType::SubSuperscript,
+            position: ScriptPosition::Right,
+        });
+    }
+
+    #[test]
+    fn limits_repeated_last_wins() {
+        // Multiple modifiers — the last one wins (amsmath §7.3).
+        let store = Storage::new();
+        let parser = Parser::new(r"\sum\nolimits\limits\nolimits_a^b", &store);
+        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
+        assert_eq!(events[0], Event::Script {
+            ty: ScriptType::SubSuperscript,
+            position: ScriptPosition::Right,
+        });
+    }
+
+    #[test]
+    fn limits_on_oint() {
+        // `\oint` is a non-`\sum` big operator that defaults to `Right`.
+        let store = Storage::new();
+        let parser = Parser::new(r"\oint\limits_C f", &store);
+        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
+        assert_eq!(events[0], Event::Script {
+            ty: ScriptType::Subscript,
+            position: ScriptPosition::AboveBelow,
+        });
+    }
+
+    #[test]
+    fn nolimits_on_underbrace() {
+        // KaTeX/MathJax tolerate `\nolimits` after `\underbrace`, downgrading
+        // its default `AboveBelow` position to `Right`. Without this fix the
+        // parser errored with `unknown primitive command found`.
+        let store = Storage::new();
+        let parser = Parser::new(r"\underbrace{ab}\nolimits_x", &store);
+        let events = parser
+            .collect::<Result<Vec<_>, ParserError>>()
+            .expect("should parse cleanly");
+        assert_eq!(events[0], Event::Script {
+            ty: ScriptType::Subscript,
+            position: ScriptPosition::Right,
+        });
+    }
+
+    #[test]
+    fn injlim_and_friends_parse() {
+        let store = Storage::new();
+        for src in &[
+            r"\injlim", r"\projlim", r"\varinjlim", r"\varliminf",
+            r"\varlimsup", r"\varprojlim",
+        ] {
+            let parser = Parser::new(src, &store);
+            parser
+                .collect::<Result<Vec<_>, ParserError>>()
+                .unwrap_or_else(|e| panic!("`{}` should parse, but got: {}", src, e));
+        }
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -815,10 +815,13 @@ mod tests {
         let store = Storage::new();
         let parser = Parser::new(r"\int\limits_a^b", &store);
         let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(events[0], Event::Script {
-            ty: ScriptType::SubSuperscript,
-            position: ScriptPosition::AboveBelow,
-        });
+        assert_eq!(
+            events[0],
+            Event::Script {
+                ty: ScriptType::SubSuperscript,
+                position: ScriptPosition::AboveBelow,
+            }
+        );
     }
 
     #[test]
@@ -826,10 +829,13 @@ mod tests {
         let store = Storage::new();
         let parser = Parser::new(r"\int\nolimits_a^b", &store);
         let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(events[0], Event::Script {
-            ty: ScriptType::SubSuperscript,
-            position: ScriptPosition::Right,
-        });
+        assert_eq!(
+            events[0],
+            Event::Script {
+                ty: ScriptType::SubSuperscript,
+                position: ScriptPosition::Right,
+            }
+        );
     }
 
     #[test]
@@ -839,10 +845,13 @@ mod tests {
         let store = Storage::new();
         let parser = Parser::new(r"\sum^x\limits_y", &store);
         let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(events[0], Event::Script {
-            ty: ScriptType::SubSuperscript,
-            position: ScriptPosition::AboveBelow,
-        });
+        assert_eq!(
+            events[0],
+            Event::Script {
+                ty: ScriptType::SubSuperscript,
+                position: ScriptPosition::AboveBelow,
+            }
+        );
     }
 
     #[test]
@@ -852,10 +861,13 @@ mod tests {
         let store = Storage::new();
         let parser = Parser::new(r"\sum^x\nolimits_y", &store);
         let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(events[0], Event::Script {
-            ty: ScriptType::SubSuperscript,
-            position: ScriptPosition::Right,
-        });
+        assert_eq!(
+            events[0],
+            Event::Script {
+                ty: ScriptType::SubSuperscript,
+                position: ScriptPosition::Right,
+            }
+        );
     }
 
     #[test]
@@ -864,10 +876,13 @@ mod tests {
         let store = Storage::new();
         let parser = Parser::new(r"\sum\nolimits\limits\nolimits_a^b", &store);
         let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(events[0], Event::Script {
-            ty: ScriptType::SubSuperscript,
-            position: ScriptPosition::Right,
-        });
+        assert_eq!(
+            events[0],
+            Event::Script {
+                ty: ScriptType::SubSuperscript,
+                position: ScriptPosition::Right,
+            }
+        );
     }
 
     #[test]
@@ -876,10 +891,13 @@ mod tests {
         let store = Storage::new();
         let parser = Parser::new(r"\oint\limits_C f", &store);
         let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(events[0], Event::Script {
-            ty: ScriptType::Subscript,
-            position: ScriptPosition::AboveBelow,
-        });
+        assert_eq!(
+            events[0],
+            Event::Script {
+                ty: ScriptType::Subscript,
+                position: ScriptPosition::AboveBelow,
+            }
+        );
     }
 
     #[test]
@@ -892,10 +910,13 @@ mod tests {
         let events = parser
             .collect::<Result<Vec<_>, ParserError>>()
             .expect("should parse cleanly");
-        assert_eq!(events[0], Event::Script {
-            ty: ScriptType::Subscript,
-            position: ScriptPosition::Right,
-        });
+        assert_eq!(
+            events[0],
+            Event::Script {
+                ty: ScriptType::Subscript,
+                position: ScriptPosition::Right,
+            }
+        );
     }
 
     #[test]
@@ -905,10 +926,13 @@ mod tests {
         let store = Storage::new();
         let parser = Parser::new(r"\int_a^b\limits", &store);
         let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(events[0], Event::Script {
-            ty: ScriptType::SubSuperscript,
-            position: ScriptPosition::AboveBelow,
-        });
+        assert_eq!(
+            events[0],
+            Event::Script {
+                ty: ScriptType::SubSuperscript,
+                position: ScriptPosition::AboveBelow,
+            }
+        );
     }
 
     #[test]
@@ -918,10 +942,13 @@ mod tests {
         let store = Storage::new();
         let parser = Parser::new(r"\sum_a^b\nolimits", &store);
         let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-        assert_eq!(events[0], Event::Script {
-            ty: ScriptType::SubSuperscript,
-            position: ScriptPosition::Right,
-        });
+        assert_eq!(
+            events[0],
+            Event::Script {
+                ty: ScriptType::SubSuperscript,
+                position: ScriptPosition::Right,
+            }
+        );
     }
 
     #[test]
@@ -955,8 +982,12 @@ mod tests {
     fn injlim_and_friends_parse() {
         let store = Storage::new();
         for src in &[
-            r"\injlim", r"\projlim", r"\varinjlim", r"\varliminf",
-            r"\varlimsup", r"\varprojlim",
+            r"\injlim",
+            r"\projlim",
+            r"\varinjlim",
+            r"\varliminf",
+            r"\varlimsup",
+            r"\varprojlim",
         ] {
             let parser = Parser::new(src, &store);
             parser

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -14,7 +14,7 @@ pub fn definition<'a>(input: &mut &'a str) -> InnerResult<(&'a str, &'a str, &'a
     let control_sequence = control_sequence(input)?;
     let (parameter_text, rest) = input.split_once('{').ok_or(ErrorKind::MissingExpansion)?;
 
-    if let Some(idx) = parameter_text.find(|c: char| c == '%' || c == '}') {
+    if let Some(idx) = parameter_text.find(['%', '}']) {
         return Err(if parameter_text.as_bytes()[idx] == b'%' {
             ErrorKind::CommentInParamText
         } else {

--- a/src/parser/primitives.rs
+++ b/src/parser/primitives.rs
@@ -1800,7 +1800,7 @@ impl<'b, 'store> InnerParser<'b, 'store> {
                 if let Some(style) = style {
                     self.buffer.push(I::Event(E::StateChange(SC::Style(style))));
                 }
-                if horizontal_lines.len() > 0 {
+                if !horizontal_lines.is_empty() {
                     self.buffer
                         .push(I::Event(E::EnvironmentFlow(EnvironmentFlow::StartLines {
                             lines: horizontal_lines,

--- a/src/parser/primitives.rs
+++ b/src/parser/primitives.rs
@@ -147,6 +147,36 @@ impl<'b, 'store> InnerParser<'b, 'store> {
                 self.state.script_position = SP::Movable;
                 E::Content(C::Function("lim sup"))
             }
+            "injlim" => {
+                self.state.allow_script_modifiers = true;
+                self.state.script_position = SP::Movable;
+                E::Content(C::Function("inj lim"))
+            }
+            "projlim" => {
+                self.state.allow_script_modifiers = true;
+                self.state.script_position = SP::Movable;
+                E::Content(C::Function("proj lim"))
+            }
+            "varliminf" => {
+                self.state.allow_script_modifiers = true;
+                self.state.script_position = SP::Movable;
+                E::Content(C::Function("lim"))
+            }
+            "varlimsup" => {
+                self.state.allow_script_modifiers = true;
+                self.state.script_position = SP::Movable;
+                E::Content(C::Function("lim"))
+            }
+            "varinjlim" => {
+                self.state.allow_script_modifiers = true;
+                self.state.script_position = SP::Movable;
+                E::Content(C::Function("lim"))
+            }
+            "varprojlim" => {
+                self.state.allow_script_modifiers = true;
+                self.state.script_position = SP::Movable;
+                E::Content(C::Function("lim"))
+            }
 
             "operatorname" => {
                 self.state.allow_script_modifiers = true;
@@ -641,22 +671,27 @@ impl<'b, 'store> InnerParser<'b, 'store> {
             // Groups
             "overgroup" => {
                 self.state.script_position = SP::AboveBelow;
+                self.state.allow_script_modifiers = true;
                 return self.accent('⏠', true);
             }
             "undergroup" => {
                 self.state.script_position = SP::AboveBelow;
+                self.state.allow_script_modifiers = true;
                 return self.underscript('⏡');
             }
             "overbrace" => {
                 self.state.script_position = SP::AboveBelow;
+                self.state.allow_script_modifiers = true;
                 return self.accent('⏞', true);
             }
             "underbrace" => {
                 self.state.script_position = SP::AboveBelow;
+                self.state.allow_script_modifiers = true;
                 return self.underscript('⏟');
             }
             "underparen" => {
                 self.state.script_position = SP::AboveBelow;
+                self.state.allow_script_modifiers = true;
                 return self.underscript('⏝');
             }
 


### PR DESCRIPTION
Previously, `\limits` and `\nolimits` were only consumed by the script parser right after the operator and before any sub/superscript, so inputs accepted by amsmath/MathJax/KaTeX failed:

- `\sum^x\limits_y`: the modifier between the two scripts was emitted as an unknown control sequence, breaking the surrounding script.
- `\underbrace{…}\limits_x` and `\underbrace{…}\nolimits_x`: the modifier was rejected because `\underbrace` (and friends) never flipped `allow_script_modifiers` on. Per amsmath §7.3, repeated modifiers are allowed and the last one wins.
- `\injlim`, `\projlim`, `\varinjlim`, `\varliminf`, `\varlimsup`, `\varprojlim`: missing entirely.

The script parser now re-checks for `\limits`/`\nolimits` between the first and second script and again after the second, updating `script_position` accordingly. 

`\overbrace`, `\underbrace`, `\overgroup`, `\undergroup`, and `\underparen` now allow script modifiers so `\nolimits` can downgrade their default above/below placement to right-side scripts. The six missing lim-like operators join `\lim`/`\liminf`/`\limsup` as movable-limit functions.
