### PR TITLE
fix(mathml): Escape HTML special chars in \text output

### DIFF
--- a/src/mathml.rs
+++ b/src/mathml.rs
@@ -592,7 +592,7 @@ where
                 if text.starts_with(char::is_whitespace) {
                     self.writer.write_all(b"&nbsp;")?;
                 }
-                self.writer.write_all(trimmed.as_bytes())?;
+                write_escaped(&mut self.writer, trimmed)?;
                 if text.ends_with(char::is_whitespace) {
                     self.writer.write_all(b"&nbsp;")?;
                 }
@@ -1472,4 +1472,26 @@ where
     E: std::error::Error,
 {
     MathmlWriter::new(parser, writer, config).write()
+}
+
+fn write_escaped<W: io::Write>(writer: &mut W, s: &str) -> io::Result<()> {
+    let bytes = s.as_bytes();
+    let mut start = 0;
+    for (i, &b) in bytes.iter().enumerate() {
+        let replacement: &[u8] = match b {
+            b'&' => b"&amp;",
+            b'<' => b"&lt;",
+            b'>' => b"&gt;",
+            _ => continue,
+        };
+        if start < i {
+            writer.write_all(&bytes[start..i])?;
+        }
+        writer.write_all(replacement)?;
+        start = i + 1;
+    }
+    if start < bytes.len() {
+        writer.write_all(&bytes[start..])?;
+    }
+    Ok(())
 }

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -115,3 +115,22 @@ fn fuzz_suffix_bounds_check() {
     let parser = Parser::new("\0\\def\\]a#1  {}f\\]ar3c%\\", &storage);
     for _ in parser {}
 }
+
+#[test]
+fn text_escapes_html_special_chars() {
+    for (input, expected) in [
+        (r"\text{a < b > c & d}", "a &lt; b &gt; c &amp; d"),
+        (r"\text{<>&}", "&lt;&gt;&amp;"),
+        (r"\text{<<&&>>}", "&lt;&lt;&amp;&amp;&gt;&gt;"),
+        (r"\text{plain}", "plain"),
+    ] {
+        let storage = Storage::new();
+        let parser = Parser::new(input, &storage);
+        let mut out = String::new();
+        push_mathml(&mut out, parser, Default::default()).unwrap();
+        assert!(
+            out.contains(expected),
+            "expected {expected:?} in output for {input:?}, got {out}"
+        );
+    }
+}


### PR DESCRIPTION
Closes https://github.com/carloskiki/pulldown-latex/issues/33