### PR TITLE
fix(parser): Stop greedy digit consumption in command arguments

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -724,6 +724,68 @@ mod tests {
     }
 
     #[test]
+    fn non_greedy_number_argument() {
+        // arguments to commands without braces should only consume
+        // a single token, not greedily consume multiple digits. `\frac12`
+        // must parse as `\frac{1}{2}`, not `\frac{12}{}`.
+        let store = Storage::new();
+        let parser = Parser::new(r"\frac12", &store);
+        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
+
+        assert_eq!(
+            events,
+            vec![
+                Event::Visual(Visual::Fraction(None)),
+                Event::Content(Content::Number("1")),
+                Event::Content(Content::Number("2")),
+            ]
+        );
+    }
+
+    #[test]
+    fn non_greedy_number_argument_sqrt() {
+        // `\sqrt12` must parse as `\sqrt{1}` followed by `2`, not `\sqrt{12}`.
+        let store = Storage::new();
+        let parser = Parser::new(r"\sqrt12", &store);
+        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
+
+        assert_eq!(
+            events,
+            vec![
+                Event::Visual(Visual::SquareRoot),
+                Event::Content(Content::Number("1")),
+                Event::Content(Content::Number("2")),
+            ]
+        );
+    }
+
+    #[test]
+    fn non_greedy_decimal_argument() {
+        // The greedy-digit path also consumed `.` and `,`. As an argument,
+        // only the first digit should be taken; the `.` and following digits
+        // remain in the outer stream.
+        let store = Storage::new();
+        let parser = Parser::new(r"\frac1.5{x}", &store);
+        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
+
+        assert_eq!(
+            events,
+            vec![
+                Event::Visual(Visual::Fraction(None)),
+                Event::Content(Content::Number("1")),
+                Event::Content(Content::Punctuation('.')),
+                Event::Content(Content::Number("5")),
+                Event::Begin(Grouping::Normal),
+                Event::Content(Content::Ordinary {
+                    content: 'x',
+                    stretchy: false
+                }),
+                Event::End,
+            ]
+        );
+    }
+
+    #[test]
     fn error() {
         let store = Storage::new();
         let parser = Parser::new(

--- a/src/parser/primitives.rs
+++ b/src/parser/primitives.rs
@@ -86,15 +86,20 @@ impl<'b, 'store> InnerParser<'b, 'store> {
 
             '0'..='9' => {
                 let content = token.as_str();
-                let mut len = content
-                    .chars()
-                    .skip(1)
-                    .take_while(|&c| matches!(c, '.' | ',' | '0'..='9'))
-                    .count()
-                    + 1;
-                if matches!(content.as_bytes()[len - 1], b'.' | b',') {
-                    len -= 1;
-                }
+                let len = if self.state.handling_argument {
+                    1
+                } else {
+                    let mut len = content
+                        .chars()
+                        .skip(1)
+                        .take_while(|&c| matches!(c, '.' | ',' | '0'..='9'))
+                        .count()
+                        + 1;
+                    if matches!(content.as_bytes()[len - 1], b'.' | b',') {
+                        len -= 1;
+                    }
+                    len
+                };
                 let (number, rest) = content.split_at(len);
                 self.content = rest;
                 self.buffer


### PR DESCRIPTION
Without braces, `\frac12` was being parsed as `\frac{12}{}` because the digit handler greedily consumed consecutive digits regardless of context. 

LaTeX semantics require a single un-braced argument to be exactly one token, so this only matters when handling an argument. Gating the greedy path on `!handling_argument` preserves bare-number parsing (`123` outside arguments stays one number) while making argument parsing correct.

Fixes #31 