### PR TITLE
feat(parser): add \strut alongside existing \mathstrut

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -528,7 +528,7 @@ struct ExpansionSpan<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::event::{Content, DelimiterType, RelationContent, Visual};
+    use crate::event::{Content, DelimiterType, Dimension, DimensionUnit, RelationContent, Visual};
 
     use super::*;
 
@@ -778,6 +778,36 @@ mod tests {
                     ty: DelimiterType::Close
                 }),
             ]
+        );
+    }
+
+    #[test]
+    fn mathstrut() {
+        let store = Storage::new();
+        let parser = Parser::new(r"\mathstrut", &store);
+        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
+
+        assert_eq!(
+            events,
+            vec![Event::Space {
+                width: None,
+                height: Some(Dimension::new(0.7, DimensionUnit::Em)),
+            }]
+        );
+    }
+
+    #[test]
+    fn strut() {
+        let store = Storage::new();
+        let parser = Parser::new(r"\strut", &store);
+        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
+
+        assert_eq!(
+            events,
+            vec![Event::Space {
+                width: None,
+                height: Some(Dimension::new(1.0, DimensionUnit::Em)),
+            },]
         );
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -782,36 +782,6 @@ mod tests {
     }
 
     #[test]
-    fn mathstrut() {
-        let store = Storage::new();
-        let parser = Parser::new(r"\mathstrut", &store);
-        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-
-        assert_eq!(
-            events,
-            vec![Event::Space {
-                width: None,
-                height: Some(Dimension::new(0.7, DimensionUnit::Em)),
-            }]
-        );
-    }
-
-    #[test]
-    fn strut() {
-        let store = Storage::new();
-        let parser = Parser::new(r"\strut", &store);
-        let events = parser.collect::<Result<Vec<_>, ParserError>>().unwrap();
-
-        assert_eq!(
-            events,
-            vec![Event::Space {
-                width: None,
-                height: Some(Dimension::new(1.0, DimensionUnit::Em)),
-            },]
-        );
-    }
-
-    #[test]
     fn expansions_in_groups() {
         let store = Storage::new();
         let mut parser = Parser::new(

--- a/src/parser/primitives.rs
+++ b/src/parser/primitives.rs
@@ -700,6 +700,10 @@ impl<'b, 'store> InnerParser<'b, 'store> {
                 width: None,
                 height: Some(Dimension::new(0.7, DimensionUnit::Em)),
             },
+            "strut" => E::Space {
+                width: None,
+                height: Some(Dimension::new(1.0, DimensionUnit::Em)),
+            },
             "~" | "nobreakspace" => E::Content(C::Text("&nbsp;")),
             // Variable spacing
             "kern" => {


### PR DESCRIPTION
[`\mathstrut`](https://latexref.xyz/_005cmathstrut.html) was already supported as a zero-width Space with a 0.7em height. 


This PR adds [`\strut`](https://latexref.xyz/_005cstrut.html) as a text-mode-sized counterpart (1.0em height), emitted as the same kind of `Space` event.